### PR TITLE
Fixed a typo in the class name

### DIFF
--- a/src/Iyzipay/Model/Mapper/Subscription/SubscriptionPricingPlanMapper.php
+++ b/src/Iyzipay/Model/Mapper/Subscription/SubscriptionPricingPlanMapper.php
@@ -4,7 +4,7 @@ namespace Iyzipay\Model\Mapper\Subscription;
 
 use Iyzipay\Model\Subscription\SubscriptionPricingPlan;
 
-class SubscriptionPricingplanMapper extends SubscriptionPricingPlanResourceMapper
+class SubscriptionPricingPlanMapper extends SubscriptionPricingPlanResourceMapper
 {
     public static function create($rawResult = null)
     {


### PR DESCRIPTION
The typo that violates the PSR-4 standards in class name has been fixed.